### PR TITLE
add big-redirects rules

### DIFF
--- a/.cursor/rules/checks.mdc
+++ b/.cursor/rules/checks.mdc
@@ -284,6 +284,134 @@ export const Severity = {
 ### Testing
 
 - Write unit tests in `index.spec.ts` next to the check.
+- Use `runCheck` from the engine to test checks:
+
+```ts
+import { createMockRequest, createMockResponse, runCheck } from "engine";
+import { describe, expect, it } from "vitest";
+
+import myCheck from "./index";
+
+describe("My Check", () => {
+  it("should detect vulnerability when check runs", async () => {
+    const request = createMockRequest({
+      id: "1",
+      host: "example.com",
+      method: "GET",
+      path: "/test",
+    });
+
+    const response = createMockResponse({
+      id: "1",
+      code: 200,
+      headers: { "content-type": ["text/html"] },
+      body: "Response body",
+    });
+
+    const executionHistory = await runCheck(myCheck, [
+      { request, response },
+    ]);
+
+    expect(executionHistory).toMatchObject([
+      {
+        checkId: "my-check",
+        targetRequestId: "1",
+        status: "completed",
+        steps: [
+          {
+            stepName: "myStep",
+            findings: [
+              {
+                name: "Expected Finding",
+                severity: "low",
+              },
+            ],
+            result: "done",
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("should not run when conditions are not met", async () => {
+    const request = createMockRequest({
+      id: "2",
+      host: "example.com",
+      method: "GET",
+      path: "/test",
+    });
+
+    const response = createMockResponse({
+      id: "2",
+      code: 404, // This might not meet the check's 'when' condition
+      headers: {},
+      body: "Not found",
+    });
+
+    const executionHistory = await runCheck(myCheck, [
+      { request, response },
+    ]);
+
+    // When check doesn't run, execution history is empty
+    expect(executionHistory).toMatchObject([]);
+  });
+
+  it("should find no issues when no vulnerability exists", async () => {
+    const request = createMockRequest({
+      id: "3",
+      host: "example.com",
+      method: "GET",
+      path: "/test",
+    });
+
+    const response = createMockResponse({
+      id: "3",
+      code: 200, // Meets the check's 'when' condition
+      headers: { "content-type": ["text/html"] },
+      body: "Safe response body",
+    });
+
+    const executionHistory = await runCheck(myCheck, [
+      { request, response },
+    ]);
+
+    // When check runs but finds no issues, execution history is non-empty with empty findings
+    expect(executionHistory).toMatchObject([
+      {
+        checkId: "my-check",
+        targetRequestId: "3",
+        status: "completed",
+        steps: [
+          {
+            stepName: "myStep",
+            findings: [], // Empty findings array
+            result: "done",
+          },
+        ],
+      },
+    ]);
+  });
+});
+```
+
+**Important**: `runCheck` returns an `ExecutionHistory` which is an array of `CheckExecutionRecord` objects. Each record contains:
+
+- `checkId`: The check ID
+- `targetRequestId`: The request ID
+- `status`: "completed" or "failed"
+- `steps`: Array of step execution records with findings
+- `finalOutput`: The check output (if completed)
+
+**Critical**: There are two distinct scenarios when a check doesn't produce findings:
+
+1. **Check doesn't run at all** (when `when` condition returns false) → Execution history is **empty** (`[]`)
+2. **Check runs but finds no issues** (when `when` condition returns true but no findings) → Execution history is **non-empty** with empty findings array
+
+Use descriptive test names to distinguish these scenarios:
+
+- `"should not run on X"` for scenario 1
+- `"should find no issues on X"` for scenario 2
+
 - Validate locally from the repo root:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "build": "caido-dev build",
     "watch": "caido-dev watch",
     "lint": "eslint --fix packages/*/src",
-    "test": "vitest run"
+    "test": "vitest run",
+    "validate": "pnpm run typecheck && pnpm run lint && pnpm run test"
   },
   "devDependencies": {
     "@caido-community/dev": "^0.1.6",

--- a/packages/backend/src/checks/big-redirects/index.spec.ts
+++ b/packages/backend/src/checks/big-redirects/index.spec.ts
@@ -1,0 +1,417 @@
+import { createMockRequest, createMockResponse, runCheck } from "engine";
+import { describe, expect, it } from "vitest";
+
+import bigRedirectsCheck from "./index";
+
+describe("Big Redirects Check", () => {
+  it("should not run on non-redirect responses", async () => {
+    const request = createMockRequest({
+      id: "1",
+      host: "example.com",
+      method: "GET",
+      path: "/test",
+    });
+
+    const response = createMockResponse({
+      id: "1",
+      code: 200,
+      headers: { "content-type": ["text/html"] },
+      body: "Normal response content",
+    });
+
+    const executionHistory = await runCheck(bigRedirectsCheck, [
+      { request, response },
+    ]);
+
+    expect(executionHistory).toMatchObject([]);
+  });
+
+  it("should not run on 304 Not Modified responses", async () => {
+    const request = createMockRequest({
+      id: "2",
+      host: "example.com",
+      method: "GET",
+      path: "/test",
+    });
+
+    const response = createMockResponse({
+      id: "2",
+      code: 304,
+      headers: { location: ["https://example.com/redirect"] },
+      body: "Not modified",
+    });
+
+    const executionHistory = await runCheck(bigRedirectsCheck, [
+      { request, response },
+    ]);
+
+    expect(executionHistory).toMatchObject([]);
+  });
+
+  it("should find no issues on redirects without location header", async () => {
+    const request = createMockRequest({
+      id: "3",
+      host: "example.com",
+      method: "GET",
+      path: "/test",
+    });
+
+    const response = createMockResponse({
+      id: "3",
+      code: 302,
+      headers: {},
+      body: "Redirect without location",
+    });
+
+    const executionHistory = await runCheck(bigRedirectsCheck, [
+      { request, response },
+    ]);
+
+    expect(executionHistory).toMatchObject([
+      {
+        checkId: "big-redirects",
+        targetRequestId: "3",
+        status: "completed",
+        steps: [
+          {
+            stepName: "analyzeRedirect",
+            findings: [],
+            result: "done",
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("should find no issues on normal-sized redirect responses", async () => {
+    const request = createMockRequest({
+      id: "4",
+      host: "example.com",
+      method: "GET",
+      path: "/test",
+    });
+
+    const locationUrl = "https://example.com/redirect";
+    const response = createMockResponse({
+      id: "4",
+      code: 302,
+      headers: { location: [locationUrl] },
+      body: "Redirecting...", // Small body, should not trigger
+    });
+
+    const executionHistory = await runCheck(bigRedirectsCheck, [
+      { request, response },
+    ]);
+
+    expect(executionHistory).toMatchObject([
+      {
+        checkId: "big-redirects",
+        targetRequestId: "4",
+        status: "completed",
+        steps: [
+          {
+            stepName: "analyzeRedirect",
+            findings: [],
+            result: "done",
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("should detect oversized redirect responses", async () => {
+    const request = createMockRequest({
+      id: "5",
+      host: "example.com",
+      method: "GET",
+      path: "/test",
+    });
+
+    const locationUrl = "https://example.com/redirect";
+    const largeBody = "A".repeat(500); // Much larger than expected (locationUrl.length + 300 = ~340)
+
+    const response = createMockResponse({
+      id: "5",
+      code: 302,
+      headers: { location: [locationUrl] },
+      body: largeBody,
+    });
+
+    const executionHistory = await runCheck(bigRedirectsCheck, [
+      { request, response },
+    ]);
+
+    expect(executionHistory).toMatchObject([
+      {
+        checkId: "big-redirects",
+        targetRequestId: "5",
+        status: "completed",
+        steps: [
+          {
+            stepName: "analyzeRedirect",
+            findings: [
+              {
+                name: "Big Redirects - Oversized Response",
+                severity: "low",
+              },
+            ],
+            result: "done",
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("should detect multiple href links in redirect response", async () => {
+    const request = createMockRequest({
+      id: "6",
+      host: "example.com",
+      method: "GET",
+      path: "/test",
+    });
+
+    const locationUrl = "https://example.com/redirect";
+    const bodyWithMultipleHrefs = `
+      <html>
+        <head><link href="/style.css" rel="stylesheet"></head>
+        <body>
+          <a href="/link1">Link 1</a>
+          <a href="/link2">Link 2</a>
+          <a href="/link3">Link 3</a>
+        </body>
+      </html>
+    `;
+
+    const response = createMockResponse({
+      id: "6",
+      code: 301,
+      headers: { location: [locationUrl] },
+      body: bodyWithMultipleHrefs,
+    });
+
+    const executionHistory = await runCheck(bigRedirectsCheck, [
+      { request, response },
+    ]);
+
+    expect(executionHistory).toMatchObject([
+      {
+        checkId: "big-redirects",
+        targetRequestId: "6",
+        status: "completed",
+        steps: [
+          {
+            stepName: "analyzeRedirect",
+            findings: [
+              {
+                name: "Big Redirects - Multiple Href Links",
+                severity: "low",
+              },
+            ],
+            result: "done",
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("should detect both oversized response and multiple href links", async () => {
+    const request = createMockRequest({
+      id: "7",
+      host: "example.com",
+      method: "GET",
+      path: "/test",
+    });
+
+    const locationUrl = "https://example.com/redirect";
+    const largeBodyWithMultipleHrefs = `
+      <html>
+        <head><link href="/style.css" rel="stylesheet"></head>
+        <body>
+          <a href="/link1">Link 1</a>
+          <a href="/link2">Link 2</a>
+          <a href="/link3">Link 3</a>
+          ${"A".repeat(500)}
+        </body>
+      </html>
+    `;
+
+    const response = createMockResponse({
+      id: "7",
+      code: 302,
+      headers: { location: [locationUrl] },
+      body: largeBodyWithMultipleHrefs,
+    });
+
+    const executionHistory = await runCheck(bigRedirectsCheck, [
+      { request, response },
+    ]);
+
+    expect(executionHistory).toMatchObject([
+      {
+        checkId: "big-redirects",
+        targetRequestId: "7",
+        status: "completed",
+        steps: [
+          {
+            stepName: "analyzeRedirect",
+            findings: [
+              {
+                name: "Big Redirects - Oversized Response",
+                severity: "low",
+              },
+              {
+                name: "Big Redirects - Multiple Href Links",
+                severity: "low",
+              },
+            ],
+            result: "done",
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("should handle different redirect status codes", async () => {
+    const redirectCodes = [300, 301, 302, 303, 307, 308];
+
+    for (let i = 0; i < redirectCodes.length; i++) {
+      const code = redirectCodes[i]!;
+      const request = createMockRequest({
+        id: `8-${i}`,
+        host: "example.com",
+        method: "GET",
+        path: "/test",
+      });
+
+      const locationUrl = "https://example.com/redirect";
+      const largeBody = "A".repeat(500);
+
+      const response = createMockResponse({
+        id: `8-${i}`,
+        code,
+        headers: { location: [locationUrl] },
+        body: largeBody,
+      });
+
+      const executionHistory = await runCheck(bigRedirectsCheck, [
+        { request, response },
+      ]);
+
+      expect(executionHistory).toMatchObject([
+        {
+          checkId: "big-redirects",
+          targetRequestId: `8-${i}`,
+          status: "completed",
+          steps: [
+            {
+              stepName: "analyzeRedirect",
+              findings: [
+                {
+                  name: "Big Redirects - Oversized Response",
+                  severity: "low",
+                },
+              ],
+              result: "done",
+            },
+          ],
+        },
+      ]);
+    }
+  });
+
+  it("should handle case-insensitive href detection", async () => {
+    const request = createMockRequest({
+      id: "9",
+      host: "example.com",
+      method: "GET",
+      path: "/test",
+    });
+
+    const locationUrl = "https://example.com/redirect";
+    const bodyWithCaseVariations = `
+      <html>
+        <head><link HREF="/style.css" rel="stylesheet"></head>
+        <body>
+          <a href="/link1">Link 1</a>
+          <a HREF="/link2">Link 2</a>
+          <a href="/link3">Link 3</a>
+        </body>
+      </html>
+    `;
+
+    const response = createMockResponse({
+      id: "9",
+      code: 302,
+      headers: { location: [locationUrl] },
+      body: bodyWithCaseVariations,
+    });
+
+    const executionHistory = await runCheck(bigRedirectsCheck, [
+      { request, response },
+    ]);
+
+    expect(executionHistory).toMatchObject([
+      {
+        checkId: "big-redirects",
+        targetRequestId: "9",
+        status: "completed",
+        steps: [
+          {
+            stepName: "analyzeRedirect",
+            findings: [
+              {
+                name: "Big Redirects - Multiple Href Links",
+                severity: "low",
+              },
+            ],
+            result: "done",
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("should find no issues on single href link", async () => {
+    const request = createMockRequest({
+      id: "10",
+      host: "example.com",
+      method: "GET",
+      path: "/test",
+    });
+
+    const locationUrl = "https://example.com/redirect";
+    const bodyWithSingleHref = `
+      <html>
+        <body>
+          <a href="/single-link">Single Link</a>
+        </body>
+      </html>
+    `;
+
+    const response = createMockResponse({
+      id: "10",
+      code: 302,
+      headers: { location: [locationUrl] },
+      body: bodyWithSingleHref,
+    });
+
+    const executionHistory = await runCheck(bigRedirectsCheck, [
+      { request, response },
+    ]);
+
+    expect(executionHistory).toMatchObject([
+      {
+        checkId: "big-redirects",
+        targetRequestId: "10",
+        status: "completed",
+        steps: [
+          {
+            stepName: "analyzeRedirect",
+            findings: [],
+            result: "done",
+          },
+        ],
+      },
+    ]);
+  });
+});

--- a/packages/backend/src/checks/big-redirects/index.ts
+++ b/packages/backend/src/checks/big-redirects/index.ts
@@ -95,7 +95,7 @@ export default defineCheck<State>(({ step }) => {
       description:
         "Detects redirect responses that are larger than expected or contain multiple href links, which could indicate information leakage or improper redirect implementation.",
       type: "passive",
-      tags: ["redirect", "information-disclosure", "owasp-a04", "owasp-a03"],
+      tags: ["redirect", "information-disclosure"],
       severities: [Severity.LOW],
       aggressivity: {
         minRequests: 0,

--- a/packages/backend/src/checks/big-redirects/index.ts
+++ b/packages/backend/src/checks/big-redirects/index.ts
@@ -1,0 +1,124 @@
+import {
+  defineCheck,
+  done,
+  type RuntimeContext,
+  type ScanTarget,
+  Severity,
+  type StepAction,
+} from "engine";
+
+type State = {
+  hasAnalyzed: boolean;
+};
+
+const isRedirectResponse = (statusCode: number): boolean => {
+  return statusCode >= 300 && statusCode < 400 && statusCode !== 304;
+};
+
+const getPredictedResponseSize = (redirectUriLength: number): number => {
+  return redirectUriLength + 300;
+};
+
+const countHrefOccurrences = (body: string): number => {
+  const hrefPattern = /href/gi;
+  const matches = body.match(hrefPattern);
+  return matches ? matches.length : 0;
+};
+
+export default defineCheck<State>(({ step }) => {
+  step("analyzeRedirect", ((state: State, context: RuntimeContext) => {
+    if (state.hasAnalyzed) {
+      return done({ state });
+    }
+
+    const response = context.target.response;
+    if (!response) {
+      return done({ state });
+    }
+
+    const statusCode = response.getCode();
+    if (!isRedirectResponse(statusCode)) {
+      return done({ state });
+    }
+
+    const locationHeader = response.getHeader("location");
+    const locationValue = locationHeader?.[0];
+
+    if (locationValue === undefined || locationValue === "") {
+      return done({ state });
+    }
+
+    const responseBody = response.getBody()?.toText() ?? "";
+    const responseBodyLength = responseBody.length;
+    const locationUriLength = locationValue.length;
+    const predictedSize = getPredictedResponseSize(locationUriLength);
+
+    const findings = [];
+
+    // Check for oversized redirect response
+    if (responseBodyLength > predictedSize) {
+      findings.push({
+        name: "Big Redirects - Oversized Response",
+        description: `The redirect response is larger than expected. The Location header URI length is ${locationUriLength} characters, which should result in a response body of approximately ${predictedSize} bytes. However, the actual response body is ${responseBodyLength} bytes, which is ${responseBodyLength - predictedSize} bytes larger than expected. This could indicate that sensitive information is being leaked in the redirect response.`,
+        severity: Severity.LOW,
+        correlation: {
+          requestID: context.target.request.getId(),
+          locations: [],
+        },
+      });
+    }
+
+    // Check for multiple href links in redirect response
+    const hrefCount = countHrefOccurrences(responseBody);
+    if (hrefCount > 1) {
+      findings.push({
+        name: "Big Redirects - Multiple Href Links",
+        description: `The redirect response contains ${hrefCount} href links, which is unusual for a redirect response. This could indicate that the response contains additional content that should not be present in a redirect response.`,
+        severity: Severity.LOW,
+        correlation: {
+          requestID: context.target.request.getId(),
+          locations: [],
+        },
+      });
+    }
+
+    return done({
+      state: { hasAnalyzed: true },
+      findings,
+    });
+  }) as StepAction<State>);
+
+  return {
+    metadata: {
+      id: "big-redirects",
+      name: "Big Redirects",
+      description:
+        "Detects redirect responses that are larger than expected or contain multiple href links, which could indicate information leakage or improper redirect implementation.",
+      type: "passive",
+      tags: ["redirect", "information-disclosure", "owasp-a04", "owasp-a03"],
+      severities: [Severity.LOW],
+      aggressivity: {
+        minRequests: 0,
+        maxRequests: 0,
+      },
+    },
+    initState: (): State => ({
+      hasAnalyzed: false,
+    }),
+    dedupeKey: (target: ScanTarget) => {
+      return (
+        target.request.getMethod() +
+        target.request.getHost() +
+        target.request.getPort() +
+        target.request.getPath() +
+        target.request.getQuery()
+      );
+    },
+    when: (target: ScanTarget) => {
+      return (
+        target.response !== undefined &&
+        isRedirectResponse(target.response.getCode())
+      );
+    },
+  };
+});

--- a/packages/backend/src/checks/index.ts
+++ b/packages/backend/src/checks/index.ts
@@ -1,3 +1,4 @@
+import bigRedirectsScan from "./big-redirects";
 import corsMisconfigScan from "./cors-misconfig";
 import exposedEnvScan from "./exposed-env";
 import gitConfigScan from "./git-config";
@@ -10,6 +11,7 @@ import { mysqlErrorBased } from "./sql-injection";
 
 export type CheckID = (typeof Checks)[keyof typeof Checks];
 export const Checks = {
+  BIG_REDIRECTS: "big-redirects",
   CORS_MISCONFIG: "cors-misconfig",
   EXPOSED_ENV: "exposed-env",
   GIT_CONFIG: "git-config",
@@ -23,6 +25,7 @@ export const Checks = {
 } as const;
 
 export const checks = [
+  bigRedirectsScan,
   corsMisconfigScan,
   exposedEnvScan,
   gitConfigScan,

--- a/packages/backend/src/stores/config.ts
+++ b/packages/backend/src/stores/config.ts
@@ -42,6 +42,10 @@ export class ConfigStore {
           ],
           passive: [
             {
+              checkID: Checks.BIG_REDIRECTS,
+              enabled: true,
+            },
+            {
               checkID: Checks.EXPOSED_ENV,
               enabled: false,
             },
@@ -88,6 +92,10 @@ export class ConfigStore {
             },
           ],
           passive: [
+            {
+              checkID: Checks.BIG_REDIRECTS,
+              enabled: true,
+            },
             {
               checkID: Checks.EXPOSED_ENV,
               enabled: true,
@@ -155,6 +163,10 @@ export class ConfigStore {
             },
           ],
           passive: [
+            {
+              checkID: Checks.BIG_REDIRECTS,
+              enabled: true,
+            },
             {
               checkID: Checks.EXPOSED_ENV,
               enabled: true,


### PR DESCRIPTION
This pull request introduces a new passive security check for detecting oversized HTTP redirect responses and responses containing multiple href links, which may indicate information leakage or improper redirect implementation. It also improves the developer workflow by updating testing documentation and adding a validation script. The most important changes are grouped below:

### New Security Check: Big Redirects

* Added the `big-redirects` check in `packages/backend/src/checks/big-redirects/index.ts`, which analyzes redirect responses for excessive body size and multiple href links, flagging potential information leakage.
* Registered the new check in the central checks index (`packages/backend/src/checks/index.ts`) and included it in the exported `Checks` object and the list of active checks. [[1]](diffhunk://#diff-4c3c5cb038a1bbd2679569063f29b5963ee8d397931e02dc1d49c1c9db12eec0R1) [[2]](diffhunk://#diff-4c3c5cb038a1bbd2679569063f29b5963ee8d397931e02dc1d49c1c9db12eec0R14) [[3]](diffhunk://#diff-4c3c5cb038a1bbd2679569063f29b5963ee8d397931e02dc1d49c1c9db12eec0R28)

### Default Configuration Updates

* Enabled the new `big-redirects` check by default in the passive checks configuration for multiple environments in `packages/backend/src/stores/config.ts`. [[1]](diffhunk://#diff-6ddb7be1c6e61e31cc209d5e2d1610e1593ae67d5e81d416cab92c4ed4e172b8R44-R47) [[2]](diffhunk://#diff-6ddb7be1c6e61e31cc209d5e2d1610e1593ae67d5e81d416cab92c4ed4e172b8R95-R98) [[3]](diffhunk://#diff-6ddb7be1c6e61e31cc209d5e2d1610e1593ae67d5e81d416cab92c4ed4e172b8R166-R169)

### Developer Experience Improvements

* Expanded the testing documentation in `.cursor/rules/checks.mdc` to clarify how to write and distinguish unit tests for checks, including usage of `runCheck` and expected outcomes for different scenarios.
* Added a `validate` script to `package.json` to run type checking, linting, and tests together, streamlining local validation.