### PR TITLE
Add HSTS enforcement check (#163)

### DIFF
--- a/packages/backend/src/checks/hsts-not-enforced/index.spec.ts
+++ b/packages/backend/src/checks/hsts-not-enforced/index.spec.ts
@@ -1,0 +1,81 @@
+import { createMockRequest, createMockResponse, runCheck } from "engine";
+import { describe, expect, it } from "vitest";
+
+import hstsCheck from "./index";
+
+const executeCheck = async (config: {
+  tls: boolean;
+  header?: string[];
+}): Promise<unknown[]> => {
+  const request = createMockRequest({
+    id: "req-hsts",
+    host: "example.com",
+    method: "GET",
+    path: "/",
+    tls: config.tls,
+    headers: { Host: ["example.com"] },
+  });
+
+  const headers: Record<string, string[]> = {};
+  if (config.header !== undefined) {
+    headers["strict-transport-security"] = config.header;
+  }
+
+  const response = createMockResponse({
+    id: "res-hsts",
+    code: 200,
+    headers,
+    body: "",
+  });
+
+  const execution = await runCheck(hstsCheck, [{ request, response }]);
+  return execution[0]?.steps[execution[0].steps.length - 1]?.findings ?? [];
+};
+
+describe("HSTS not enforced check", () => {
+  it("flags missing HSTS header on HTTPS responses", async () => {
+    const findings = await executeCheck({ tls: true });
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      name: "Strict-Transport-Security header missing",
+      severity: "medium",
+    });
+  });
+
+  it("flags low max-age", async () => {
+    const findings = await executeCheck({
+      tls: true,
+      header: ["max-age=1000"],
+    });
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      name: "Strict-Transport-Security max-age too low",
+      severity: "low",
+    });
+  });
+
+  it("flags missing includeSubDomains", async () => {
+    const findings = await executeCheck({
+      tls: true,
+      header: ["max-age=63072000"],
+    });
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      name: "Strict-Transport-Security missing includeSubDomains",
+      severity: "low",
+    });
+  });
+
+  it("does not flag when HSTS is properly configured", async () => {
+    const findings = await executeCheck({
+      tls: true,
+      header: ["max-age=63072000; includeSubDomains; preload"],
+    });
+    expect(findings).toHaveLength(0);
+  });
+
+  it("does not flag HTTP responses", async () => {
+    const findings = await executeCheck({ tls: false });
+    expect(findings).toHaveLength(0);
+  });
+});

--- a/packages/backend/src/checks/hsts-not-enforced/index.ts
+++ b/packages/backend/src/checks/hsts-not-enforced/index.ts
@@ -1,0 +1,137 @@
+import { defineCheck, done, Severity } from "engine";
+
+import { Tags } from "../../types";
+import { keyStrategy } from "../../utils/key";
+
+const parseMaxAge = (headerValue: string): number | undefined => {
+  const match = headerValue.match(/max-age\s*=\s*(\d+)/i);
+  if (match === null) {
+    return undefined;
+  }
+  return Number.parseInt(match[1] ?? "", 10);
+};
+
+const hasIncludeSubdomains = (headerValue: string): boolean => {
+  return /\bincludeSubDomains\b/i.test(headerValue);
+};
+
+const buildDescription = (details: {
+  reason: "missing" | "insufficientMaxAge" | "noIncludeSubdomains";
+  maxAge?: number;
+  includeSubdomains?: boolean;
+}): string => {
+  const messages: string[] = [];
+
+  if (details.reason === "missing") {
+    messages.push(
+      "The response was served over HTTPS but did not include the `Strict-Transport-Security` header.",
+    );
+  } else if (details.reason === "insufficientMaxAge") {
+    messages.push(
+      `The response sets \`Strict-Transport-Security\` with \`max-age=${details.maxAge ?? 0}\`, which is below the recommended minimum of 31536000 seconds (one year).`,
+    );
+  } else if (details.reason === "noIncludeSubdomains") {
+    messages.push(
+      "The `Strict-Transport-Security` header is missing the `includeSubDomains` directive. Subdomains may remain accessible over HTTP.",
+    );
+  }
+
+  messages.push(
+    "",
+    "Missing or weak HSTS allows browsers to downgrade back to HTTP, enabling man-in-the-middle and cookie hijacking attacks.",
+    "",
+    "Set `Strict-Transport-Security: max-age=31536000; includeSubDomains; preload` on all HTTPS responses.",
+  );
+
+  return messages.join("\n");
+};
+
+export default defineCheck<Record<never, never>>(({ step }) => {
+  step("checkHstsHeader", (state, context) => {
+    const { request, response } = context.target;
+
+    if (request.getTls() !== true || response === undefined) {
+      return done({ state });
+    }
+
+    const hstsHeader = response.getHeader("strict-transport-security");
+
+    if (hstsHeader === undefined || hstsHeader.length === 0) {
+      return done({
+        state,
+        findings: [
+          {
+            name: "Strict-Transport-Security header missing",
+            description: buildDescription({ reason: "missing" }),
+            severity: Severity.MEDIUM,
+            correlation: {
+              requestID: request.getId(),
+              locations: [],
+            },
+          },
+        ],
+      });
+    }
+
+    const headerValue = hstsHeader[0] ?? "";
+    const maxAge = parseMaxAge(headerValue);
+
+    if (maxAge === undefined || Number.isNaN(maxAge) || maxAge < 31536000) {
+      return done({
+        state,
+        findings: [
+          {
+            name: "Strict-Transport-Security max-age too low",
+            description: buildDescription({
+              reason: "insufficientMaxAge",
+              maxAge,
+            }),
+            severity: Severity.LOW,
+            correlation: {
+              requestID: request.getId(),
+              locations: [],
+            },
+          },
+        ],
+      });
+    }
+
+    if (!hasIncludeSubdomains(headerValue)) {
+      return done({
+        state,
+        findings: [
+          {
+            name: "Strict-Transport-Security missing includeSubDomains",
+            description: buildDescription({
+              reason: "noIncludeSubdomains",
+              includeSubdomains: false,
+            }),
+            severity: Severity.LOW,
+            correlation: {
+              requestID: request.getId(),
+              locations: [],
+            },
+          },
+        ],
+      });
+    }
+
+    return done({ state });
+  });
+
+  return {
+    metadata: {
+      id: "hsts-not-enforced",
+      name: "Strict Transport Security not enforced",
+      description:
+        "Detects HTTPS responses that omit the Strict-Transport-Security header or configure it insecurely.",
+      type: "passive",
+      tags: [Tags.SECURITY_HEADERS],
+      severities: [Severity.LOW, Severity.MEDIUM],
+      aggressivity: { minRequests: 0, maxRequests: 0 },
+    },
+    initState: () => ({}),
+    dedupeKey: keyStrategy().withHost().build(),
+    when: (target) => target.response !== undefined,
+  };
+});

--- a/packages/backend/src/checks/index.ts
+++ b/packages/backend/src/checks/index.ts
@@ -18,6 +18,7 @@ import emailDisclosureScan from "./email-disclosure";
 import exposedEnvScan from "./exposed-env";
 import gitConfigScan from "./git-config";
 import hashDisclosureScan from "./hash-disclosure";
+import hstsNotEnforcedScan from "./hsts-not-enforced";
 import jsonHtmlResponseScan from "./json-html-response";
 import missingContentTypeScan from "./missing-content-type";
 import openRedirectScan from "./open-redirect";
@@ -59,6 +60,7 @@ export const Checks = {
   HASH_DISCLOSURE: "hash-disclosure",
   JSON_HTML_RESPONSE: "json-html-response",
   MISSING_CONTENT_TYPE: "missing-content-type",
+  HSTS_NOT_ENFORCED: "hsts-not-enforced",
   OPEN_REDIRECT: "open-redirect",
   PATH_TRAVERSAL: "path-traversal",
   PHPINFO: "phpinfo",
@@ -99,6 +101,7 @@ export const checks = [
   hashDisclosureScan,
   jsonHtmlResponseScan,
   missingContentTypeScan,
+  hstsNotEnforcedScan,
   openRedirectScan,
   pathTraversalScan,
   phpinfoScan,

--- a/packages/backend/src/stores/config.ts
+++ b/packages/backend/src/stores/config.ts
@@ -188,6 +188,10 @@ export class ConfigStore {
               checkID: Checks.MISSING_CONTENT_TYPE,
               enabled: true,
             },
+            {
+              checkID: Checks.HSTS_NOT_ENFORCED,
+              enabled: true,
+            },
           ],
         },
         {
@@ -369,6 +373,10 @@ export class ConfigStore {
             },
             {
               checkID: Checks.MISSING_CONTENT_TYPE,
+              enabled: true,
+            },
+            {
+              checkID: Checks.HSTS_NOT_ENFORCED,
               enabled: true,
             },
           ],


### PR DESCRIPTION
## Summary
- ensure HTTPS responses expose a Strict-Transport-Security header
- flag missing headers, weak max-age values, and absent includeSubDomains
- register the passive check and enable it in the Balanced preset

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test -- --match 'HSTS not enforced'

Closes #163