### PR TITLE
Add GraphQL endpoint detector (#94)

### DIFF
--- a/packages/backend/src/checks/graphql-endpoint/index.spec.ts
+++ b/packages/backend/src/checks/graphql-endpoint/index.spec.ts
@@ -1,0 +1,58 @@
+import { createMockRequest, createMockResponse, runCheck } from "engine";
+import { describe, expect, it } from "vitest";
+
+import graphqlEndpointCheck from "./index";
+
+const runEndpointCheck = async (body: string): Promise<unknown[]> => {
+  const request = createMockRequest({
+    id: "req-graphql-endpoint",
+    host: "example.com",
+    method: "POST",
+    path: "/graphql",
+    headers: { Host: ["example.com"], "Content-Type": ["application/json"] },
+  });
+
+  const response = createMockResponse({
+    id: "res-graphql-endpoint",
+    code: 200,
+    headers: { "content-type": ["application/json"] },
+    body,
+  });
+
+  const execution = await runCheck(graphqlEndpointCheck, [
+    { request, response },
+  ]);
+  return execution[0]?.steps[execution[0].steps.length - 1]?.findings ?? [];
+};
+
+describe("GraphQL endpoint detected check", () => {
+  it("detects GraphQL validation errors", async () => {
+    const findings = await runEndpointCheck(
+      JSON.stringify({
+        errors: [
+          {
+            message: 'Cannot query field "uers" on type "Query".',
+            extensions: { code: "GRAPHQL_VALIDATION_FAILED" },
+          },
+        ],
+        data: null,
+      }),
+    );
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      name: "GraphQL endpoint detected",
+      severity: "info",
+    });
+  });
+
+  it("detects GraphQL playground pages", async () => {
+    const findings = await runEndpointCheck("<html>GraphQL Playground</html>");
+    expect(findings).toHaveLength(1);
+  });
+
+  it("ignores non-GraphQL JSON", async () => {
+    const findings = await runEndpointCheck(JSON.stringify({ message: "ok" }));
+    expect(findings).toHaveLength(0);
+  });
+});

--- a/packages/backend/src/checks/graphql-endpoint/index.ts
+++ b/packages/backend/src/checks/graphql-endpoint/index.ts
@@ -1,0 +1,105 @@
+import { defineCheck, done, Severity } from "engine";
+
+import { Tags } from "../../types";
+import { keyStrategy } from "../../utils/key";
+
+const detectFromJson = (body: string): boolean => {
+  try {
+    const parsed = JSON.parse(body) as Record<string, unknown>;
+    if (parsed === null || typeof parsed !== "object") {
+      return false;
+    }
+
+    if (parsed.data !== undefined || parsed.errors !== undefined) {
+      if (Array.isArray(parsed.errors)) {
+        for (const error of parsed.errors) {
+          if (error !== null && typeof error === "object") {
+            const message = (error as Record<string, unknown>).message;
+            if (typeof message === "string" && /graphql/i.test(message)) {
+              return true;
+            }
+
+            const extensions = (error as Record<string, unknown>).extensions;
+            if (
+              extensions !== null &&
+              typeof extensions === "object" &&
+              typeof (extensions as Record<string, unknown>).code ===
+                "string" &&
+              /(graphql|validation_failed)/i.test(
+                (extensions as Record<string, unknown>).code as string,
+              )
+            ) {
+              return true;
+            }
+          }
+        }
+      }
+
+      return true;
+    }
+  } catch {
+    // Ignore parse errors
+  }
+
+  return false;
+};
+
+const FALLBACK_REGEX = /GraphQL(?:\s+(?:Playground|schema|Error|validation))/i;
+
+const description = [
+  "The response appears to originate from a GraphQL endpoint.",
+  "",
+  "Knowing that GraphQL is in use helps attackers focus enumeration efforts (introspection, brute-forcing operations, etc.).",
+  "",
+  "Consider restricting access to GraphQL endpoints in production or enforcing strong authentication.",
+].join("\n");
+
+export default defineCheck<Record<never, never>>(({ step }) => {
+  step("detectGraphqlEndpoint", (state, context) => {
+    const { response } = context.target;
+
+    if (response === undefined) {
+      return done({ state });
+    }
+
+    const body = response.getBody()?.toText();
+    if (body === undefined || body.length === 0) {
+      return done({ state });
+    }
+
+    if (!detectFromJson(body) && !FALLBACK_REGEX.test(body)) {
+      return done({ state });
+    }
+
+    return done({
+      state,
+      findings: [
+        {
+          name: "GraphQL endpoint detected",
+          description,
+          severity: Severity.INFO,
+          correlation: {
+            requestID: context.target.request.getId(),
+            locations: [],
+          },
+        },
+      ],
+    });
+  });
+
+  return {
+    metadata: {
+      id: "graphql-endpoint-found",
+      name: "GraphQL endpoint detected",
+      description:
+        "Identifies responses that indicate the presence of a GraphQL API.",
+      type: "passive",
+      tags: [Tags.INFORMATION_DISCLOSURE],
+      severities: [Severity.INFO],
+      aggressivity: { minRequests: 0, maxRequests: 0 },
+    },
+    initState: () => ({}),
+    dedupeKey: keyStrategy().withHost().withPath().build(),
+    when: (target) => target.response !== undefined,
+  };
+});

--- a/packages/backend/src/checks/index.ts
+++ b/packages/backend/src/checks/index.ts
@@ -17,6 +17,7 @@ import directoryListingScan from "./directory-listing";
 import emailDisclosureScan from "./email-disclosure";
 import exposedEnvScan from "./exposed-env";
 import gitConfigScan from "./git-config";
+import graphqlEndpointScan from "./graphql-endpoint";
 import hashDisclosureScan from "./hash-disclosure";
 import jsonHtmlResponseScan from "./json-html-response";
 import missingContentTypeScan from "./missing-content-type";
@@ -57,6 +58,7 @@ export const Checks = {
   EXPOSED_ENV: "exposed-env",
   GIT_CONFIG: "git-config",
   HASH_DISCLOSURE: "hash-disclosure",
+  GRAPHQL_ENDPOINT_FOUND: "graphql-endpoint-found",
   JSON_HTML_RESPONSE: "json-html-response",
   MISSING_CONTENT_TYPE: "missing-content-type",
   OPEN_REDIRECT: "open-redirect",
@@ -97,6 +99,7 @@ export const checks = [
   exposedEnvScan,
   gitConfigScan,
   hashDisclosureScan,
+  graphqlEndpointScan,
   jsonHtmlResponseScan,
   missingContentTypeScan,
   openRedirectScan,

--- a/packages/backend/src/stores/config.ts
+++ b/packages/backend/src/stores/config.ts
@@ -188,6 +188,10 @@ export class ConfigStore {
               checkID: Checks.MISSING_CONTENT_TYPE,
               enabled: true,
             },
+            {
+              checkID: Checks.GRAPHQL_ENDPOINT_FOUND,
+              enabled: true,
+            },
           ],
         },
         {


### PR DESCRIPTION
## Summary
- parse GraphQL-style JSON errors and fallback HTML to identify GraphQL endpoints
- raise informational finding when responses expose GraphQL-specific metadata
- register the passive check and enable it in the Balanced preset

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test -- --match 'GraphQL endpoint'

Closes #94