### PR TITLE
Add reflected input check (#110)

### DIFF
--- a/packages/backend/src/checks/index.ts
+++ b/packages/backend/src/checks/index.ts
@@ -18,6 +18,7 @@ import emailDisclosureScan from "./email-disclosure";
 import exposedEnvScan from "./exposed-env";
 import gitConfigScan from "./git-config";
 import hashDisclosureScan from "./hash-disclosure";
+import inputReflectedScan from "./input-reflected";
 import jsonHtmlResponseScan from "./json-html-response";
 import missingContentTypeScan from "./missing-content-type";
 import openRedirectScan from "./open-redirect";
@@ -57,6 +58,7 @@ export const Checks = {
   EXPOSED_ENV: "exposed-env",
   GIT_CONFIG: "git-config",
   HASH_DISCLOSURE: "hash-disclosure",
+  INPUT_REFLECTED: "input-reflected",
   JSON_HTML_RESPONSE: "json-html-response",
   MISSING_CONTENT_TYPE: "missing-content-type",
   OPEN_REDIRECT: "open-redirect",
@@ -99,6 +101,7 @@ export const checks = [
   hashDisclosureScan,
   jsonHtmlResponseScan,
   missingContentTypeScan,
+  inputReflectedScan,
   openRedirectScan,
   pathTraversalScan,
   phpinfoScan,

--- a/packages/backend/src/checks/input-reflected/index.spec.ts
+++ b/packages/backend/src/checks/input-reflected/index.spec.ts
@@ -1,0 +1,66 @@
+import { createMockRequest, createMockResponse, runCheck } from "engine";
+import { describe, expect, it } from "vitest";
+
+import inputReflectedCheck from "./index";
+
+const executeCheck = async (config: {
+  requestQuery?: string;
+  requestBody?: string;
+  body: string;
+}): Promise<unknown[]> => {
+  const request = createMockRequest({
+    id: "req-input-reflected",
+    host: "example.com",
+    method: config.requestBody !== undefined ? "POST" : "GET",
+    path: "/search",
+    query: config.requestQuery ?? "",
+    headers: { Host: ["example.com"], "Content-Type": ["application/json"] },
+    body: config.requestBody,
+  });
+
+  const response = createMockResponse({
+    id: "res-input-reflected",
+    code: 200,
+    headers: { "content-type": ["text/html"] },
+    body: config.body,
+  });
+
+  const execution = await runCheck(inputReflectedCheck, [
+    { request, response },
+  ]);
+
+  return execution[0]?.steps[execution[0].steps.length - 1]?.findings ?? [];
+};
+
+describe("Input reflected check", () => {
+  it("flags reflected query parameters", async () => {
+    const findings = await executeCheck({
+      requestQuery: "q=test",
+      body: "<p>Results for test</p>",
+    });
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      name: "Input reflected in response",
+      severity: "low",
+    });
+  });
+
+  it("flags reflected body parameters", async () => {
+    const findings = await executeCheck({
+      requestBody: JSON.stringify({ term: "abc" }),
+      body: '<div data-term="abc"></div>',
+    });
+
+    expect(findings).toHaveLength(1);
+  });
+
+  it("ignores responses without reflections", async () => {
+    const findings = await executeCheck({
+      requestQuery: "q=test",
+      body: "<p>No echo here</p>",
+    });
+
+    expect(findings).toHaveLength(0);
+  });
+});

--- a/packages/backend/src/checks/input-reflected/index.ts
+++ b/packages/backend/src/checks/input-reflected/index.ts
@@ -1,0 +1,80 @@
+import { defineCheck, done, Severity } from "engine";
+
+import { Tags } from "../../types";
+import { extractReflectedParameters } from "../../utils";
+import { keyStrategy } from "../../utils/key";
+
+const buildDescription = (
+  reflectedParams: Array<{ name: string; valueLength: number; source: string }>,
+): string => {
+  const details = reflectedParams
+    .map((param) => {
+      const lengthText =
+        param.valueLength === 0
+          ? "empty value"
+          : param.valueLength === 1
+            ? "1 character"
+            : `${param.valueLength} characters`;
+      return `- Parameter \`${param.name}\` from ${param.source} is reflected (${lengthText}).`;
+    })
+    .join("\n");
+
+  return [
+    "User-supplied input is reflected in the response without sanitisation.",
+    "",
+    details,
+    "",
+    "Reflected input can lead to cross-site scripting or other response-splitting attacks when combined with payloads that manipulate the HTML/JavaScript context. Ensure untrusted data is escaped or encoded appropriately before being rendered.",
+  ].join("\n");
+};
+
+export default defineCheck<Record<never, never>>(({ step }) => {
+  step("detectReflections", (state, context) => {
+    const { response } = context.target;
+
+    if (response === undefined) {
+      return done({ state });
+    }
+
+    const reflected = extractReflectedParameters(context).map((param) => ({
+      name: param.name,
+      valueLength: param.value.length,
+      source: param.source,
+    }));
+
+    if (reflected.length === 0) {
+      return done({ state });
+    }
+
+    return done({
+      state,
+      findings: [
+        {
+          name: "Input reflected in response",
+          description: buildDescription(reflected),
+          severity: Severity.LOW,
+          correlation: {
+            requestID: context.target.request.getId(),
+            locations: [],
+          },
+        },
+      ],
+    });
+  });
+
+  return {
+    metadata: {
+      id: "input-reflected",
+      name: "Input reflected in response",
+      description:
+        "Detects user-supplied values that are echoed back in the HTTP response.",
+      type: "passive",
+      tags: [Tags.INFORMATION_DISCLOSURE],
+      severities: [Severity.LOW],
+      aggressivity: { minRequests: 0, maxRequests: 0 },
+    },
+    initState: () => ({}),
+    dedupeKey: keyStrategy().withHost().withPath().withQuery().build(),
+    when: (target) => target.response !== undefined,
+  };
+});

--- a/packages/backend/src/stores/config.ts
+++ b/packages/backend/src/stores/config.ts
@@ -188,6 +188,10 @@ export class ConfigStore {
               checkID: Checks.MISSING_CONTENT_TYPE,
               enabled: true,
             },
+            {
+              checkID: Checks.INPUT_REFLECTED,
+              enabled: true,
+            },
           ],
         },
         {


### PR DESCRIPTION
## Summary
- reuse parameter extraction helpers to detect reflected query/body values
- report low-severity finding listing the reflected parameter names and value lengths
- register the passive check and enable it in the Balanced preset

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test -- --match 'Input reflected'

Closes #110