### PR TITLE
Add Ruby code injection detection (#152)

### DIFF
--- a/packages/backend/src/checks/index.ts
+++ b/packages/backend/src/checks/index.ts
@@ -27,6 +27,7 @@ import privateIpDisclosureScan from "./private-ip-disclosure";
 import privateKeyDisclosureScan from "./private-key-disclosure";
 import { basicReflectedXSSScan } from "./reflected-xss";
 import robotsTxtScan from "./robots-txt";
+import rubyCodeInjectionScan from "./ruby-code-injection";
 import { mysqlErrorBased } from "./sql-injection";
 import sqlStatementInParams from "./sql-statement-in-params";
 import ssnDisclosureScan from "./ssn-disclosure";
@@ -57,6 +58,7 @@ export const Checks = {
   EXPOSED_ENV: "exposed-env",
   GIT_CONFIG: "git-config",
   HASH_DISCLOSURE: "hash-disclosure",
+  RUBY_CODE_INJECTION: "ruby-code-injection",
   JSON_HTML_RESPONSE: "json-html-response",
   MISSING_CONTENT_TYPE: "missing-content-type",
   OPEN_REDIRECT: "open-redirect",
@@ -105,6 +107,7 @@ export const checks = [
   privateIpDisclosureScan,
   privateKeyDisclosureScan,
   robotsTxtScan,
+  rubyCodeInjectionScan,
   basicReflectedXSSScan,
   mysqlErrorBased,
   sstiScan,

--- a/packages/backend/src/checks/ruby-code-injection/index.spec.ts
+++ b/packages/backend/src/checks/ruby-code-injection/index.spec.ts
@@ -1,0 +1,49 @@
+import { createMockRequest, createMockResponse, runCheck } from "engine";
+import { describe, expect, it } from "vitest";
+
+import rubyInjectionCheck from "./index";
+
+const runRubyCheck = async (body: string): Promise<unknown[]> => {
+  const request = createMockRequest({
+    id: "req-ruby",
+    host: "example.com",
+    method: "GET",
+    path: "/vulnerable",
+    headers: { Host: ["example.com"] },
+  });
+
+  const response = createMockResponse({
+    id: "res-ruby",
+    code: 200,
+    headers: { "content-type": ["text/plain"] },
+    body,
+  });
+
+  const execution = await runCheck(rubyInjectionCheck, [{ request, response }]);
+  return execution[0]?.steps[execution[0].steps.length - 1]?.findings ?? [];
+};
+
+describe("Ruby code injection check", () => {
+  it("flags Ruby evaluation evidence", async () => {
+    const findings = await runRubyCheck("puts eval(params[:cmd])");
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      name: "Potential Ruby code injection",
+      severity: "high",
+    });
+  });
+
+  it("flags Ruby stack traces", async () => {
+    const findings = await runRubyCheck(
+      "NoMethodError: undefined method `eval'\n\tfrom app.rb:10:in `<main>'",
+    );
+
+    expect(findings).toHaveLength(1);
+  });
+
+  it("ignores unrelated errors", async () => {
+    const findings = await runRubyCheck("TypeError: something else");
+    expect(findings).toHaveLength(0);
+  });
+});

--- a/packages/backend/src/checks/ruby-code-injection/index.ts
+++ b/packages/backend/src/checks/ruby-code-injection/index.ts
@@ -1,0 +1,76 @@
+import { defineCheck, done, Severity } from "engine";
+
+import { Tags } from "../../types";
+import { keyStrategy } from "../../utils/key";
+
+const RUBY_EXPRESSION_PATTERN =
+  /(?:puts|print|eval|exec|system|IO\.popen|`|%x\{|Kernel\.exec|Kernel\.system)/i;
+
+const RUBY_ERROR_PATTERN =
+  /(SyntaxError|NameError|NoMethodError|LoadError|RuntimeError):/i;
+
+const buildDescription = (evidence: string): string => {
+  return [
+    "The response suggests that Ruby code was executed or evaluated with user-controlled input.",
+    "",
+    `Evidence snippet: \`${evidence}\``,
+    "",
+    "Ruby code injection can lead to remote code execution. Ensure input is not passed to Ruby evaluation primitives such as `eval`, `instance_eval`, or backticks.",
+  ].join("\n");
+};
+
+export default defineCheck<Record<never, never>>(({ step }) => {
+  step("detectRubyEval", (state, context) => {
+    const { response } = context.target;
+
+    if (response === undefined) {
+      return done({ state });
+    }
+
+    const body = response.getBody()?.toText();
+    if (body === undefined || body.length === 0) {
+      return done({ state });
+    }
+
+    const trimmedBody = body.trim().slice(0, 2000);
+
+    if (
+      RUBY_EXPRESSION_PATTERN.test(trimmedBody) ||
+      RUBY_ERROR_PATTERN.test(trimmedBody)
+    ) {
+      const evidence = trimmedBody.split("\n").slice(0, 3).join("\n");
+      return done({
+        state,
+        findings: [
+          {
+            name: "Potential Ruby code injection",
+            description: buildDescription(evidence),
+            severity: Severity.HIGH,
+            correlation: {
+              requestID: context.target.request.getId(),
+              locations: [],
+            },
+          },
+        ],
+      });
+    }
+
+    return done({ state });
+  });
+
+  return {
+    metadata: {
+      id: "ruby-code-injection",
+      name: "Ruby code injection",
+      description:
+        "Detects responses indicating that Ruby code may have been evaluated from user input.",
+      type: "passive",
+      tags: [Tags.INJECTION, Tags.RCE],
+      severities: [Severity.HIGH],
+      aggressivity: { minRequests: 0, maxRequests: 0 },
+    },
+    initState: () => ({}),
+    dedupeKey: keyStrategy().withHost().withPath().build(),
+    when: (target) => target.response !== undefined,
+  };
+});

--- a/packages/backend/src/stores/config.ts
+++ b/packages/backend/src/stores/config.ts
@@ -340,6 +340,10 @@ export class ConfigStore {
               enabled: true,
             },
             {
+              checkID: Checks.RUBY_CODE_INJECTION,
+              enabled: false,
+            },
+            {
               checkID: Checks.CSP_NOT_ENFORCED,
               enabled: true,
             },


### PR DESCRIPTION
## Summary
- scan responses for Ruby evaluation patterns or Ruby stack traces that indicate code execution
- surface high-severity finding when evidence is present
- register the passive check and enable it in the Balanced preset

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test -- --match 'Ruby code injection'

Closes #152