### PR TITLE
Add SMTP header injection detection (#157)

### DIFF
--- a/packages/backend/src/checks/index.ts
+++ b/packages/backend/src/checks/index.ts
@@ -27,6 +27,7 @@ import privateIpDisclosureScan from "./private-ip-disclosure";
 import privateKeyDisclosureScan from "./private-key-disclosure";
 import { basicReflectedXSSScan } from "./reflected-xss";
 import robotsTxtScan from "./robots-txt";
+import smtpHeaderInjectionScan from "./smtp-header-injection";
 import { mysqlErrorBased } from "./sql-injection";
 import sqlStatementInParams from "./sql-statement-in-params";
 import ssnDisclosureScan from "./ssn-disclosure";
@@ -58,6 +59,7 @@ export const Checks = {
   GIT_CONFIG: "git-config",
   HASH_DISCLOSURE: "hash-disclosure",
   JSON_HTML_RESPONSE: "json-html-response",
+  SMTP_HEADER_INJECTION: "smtp-header-injection",
   MISSING_CONTENT_TYPE: "missing-content-type",
   OPEN_REDIRECT: "open-redirect",
   PATH_TRAVERSAL: "path-traversal",
@@ -104,6 +106,7 @@ export const checks = [
   phpinfoScan,
   privateIpDisclosureScan,
   privateKeyDisclosureScan,
+  smtpHeaderInjectionScan,
   robotsTxtScan,
   basicReflectedXSSScan,
   mysqlErrorBased,

--- a/packages/backend/src/checks/smtp-header-injection/index.spec.ts
+++ b/packages/backend/src/checks/smtp-header-injection/index.spec.ts
@@ -1,0 +1,62 @@
+import { createMockRequest, createMockResponse, runCheck } from "engine";
+import { describe, expect, it } from "vitest";
+
+import smtpHeaderInjectionCheck from "./index";
+
+const runCheckWith = async (config: {
+  query?: string;
+  body?: string;
+}): Promise<unknown[]> => {
+  const request = createMockRequest({
+    id: "req-smtp",
+    host: "example.com",
+    method: config.body !== undefined ? "POST" : "GET",
+    path: "/mail",
+    query: config.query,
+    headers: {
+      Host: ["example.com"],
+      "Content-Type": ["application/x-www-form-urlencoded"],
+    },
+    body: config.body,
+  });
+
+  const response = createMockResponse({
+    id: "res-smtp",
+    code: 200,
+    headers: { "content-type": ["text/html"] },
+    body: "",
+  });
+
+  const execution = await runCheck(smtpHeaderInjectionCheck, [
+    { request, response },
+  ]);
+
+  return execution[0]?.steps[execution[0].steps.length - 1]?.findings ?? [];
+};
+
+describe("SMTP header injection detection", () => {
+  it("flags newline injection in query string", async () => {
+    const findings = await runCheckWith({
+      query: "email=foo@example.com%0d%0aBcc:evil@example.com",
+    });
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      name: "SMTP header injection indicators",
+      severity: "medium",
+    });
+  });
+
+  it("flags header prefixes in body", async () => {
+    const findings = await runCheckWith({
+      body: "message=To:admin@example.com",
+    });
+
+    expect(findings).toHaveLength(1);
+  });
+
+  it("ignores safe inputs", async () => {
+    const findings = await runCheckWith({ query: "email=foo@example.com" });
+    expect(findings).toHaveLength(0);
+  });
+});

--- a/packages/backend/src/checks/smtp-header-injection/index.ts
+++ b/packages/backend/src/checks/smtp-header-injection/index.ts
@@ -1,0 +1,88 @@
+import { defineCheck, done, Severity } from "engine";
+
+import { Tags } from "../../types";
+import { extractParameters } from "../../utils";
+import { keyStrategy } from "../../utils/key";
+
+const HEADER_PREFIX =
+  /^(to|from|cc|bcc|reply-to|subject|mime-version|content-(type|transfer-encoding)):/i;
+const NEWLINE_SEQUENCE = /%0a|%0d|\r|\n/i;
+
+const isSuspiciousValue = (raw: string): boolean => {
+  if (raw.length === 0) {
+    return false;
+  }
+
+  if (NEWLINE_SEQUENCE.test(raw)) {
+    return true;
+  }
+
+  const decoded = decodeURIComponent(raw).toLowerCase();
+  return HEADER_PREFIX.test(decoded);
+};
+
+const buildDescription = (
+  params: Array<{ name: string; source: string }>,
+): string => {
+  const lines = params
+    .map((param) => `- Parameter \`${param.name}\` from ${param.source}`)
+    .join("\n");
+
+  return [
+    "User-controlled input contains SMTP header sequences (newline characters or header prefixes).",
+    "",
+    lines,
+    "",
+    "SMTP header injection can allow attackers to add extra recipients or modify email contents. Strip CRLF sequences and validate header fields before including user data in outbound e-mails.",
+  ].join("\n");
+};
+
+export default defineCheck<Record<never, never>>(({ step }) => {
+  step("detectSmtpInjection", (state, context) => {
+    const parameters = extractParameters(context);
+
+    const flagged = parameters.filter((param) =>
+      isSuspiciousValue(param.value),
+    );
+
+    if (flagged.length === 0) {
+      return done({ state });
+    }
+
+    const evidence = flagged.map((param) => ({
+      name: param.name,
+      source: param.source,
+    }));
+
+    return done({
+      state,
+      findings: [
+        {
+          name: "SMTP header injection indicators",
+          description: buildDescription(evidence),
+          severity: Severity.MEDIUM,
+          correlation: {
+            requestID: context.target.request.getId(),
+            locations: [],
+          },
+        },
+      ],
+    });
+  });
+
+  return {
+    metadata: {
+      id: "smtp-header-injection",
+      name: "SMTP header injection",
+      description:
+        "Detects user inputs containing SMTP header sequences, indicating possible header injection attempts.",
+      type: "passive",
+      tags: [Tags.INJECTION],
+      severities: [Severity.MEDIUM],
+      aggressivity: { minRequests: 0, maxRequests: 0 },
+    },
+    initState: () => ({}),
+    dedupeKey: keyStrategy().withHost().withPath().withQuery().build(),
+    when: () => true,
+  };
+});

--- a/packages/backend/src/stores/config.ts
+++ b/packages/backend/src/stores/config.ts
@@ -188,6 +188,10 @@ export class ConfigStore {
               checkID: Checks.MISSING_CONTENT_TYPE,
               enabled: true,
             },
+            {
+              checkID: Checks.SMTP_HEADER_INJECTION,
+              enabled: true,
+            },
           ],
         },
         {


### PR DESCRIPTION
## Summary
- inspect request parameters for CRLF or header prefixes indicating SMTP header injection attempts
- report medium severity findings listing the offending parameter names
- register the passive rule and enable it in the Balanced preset

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test -- --match 'SMTP header'

Closes #157